### PR TITLE
use python:3-slim and non-root user; add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__
+bin
+Dockerfile
+LICENSE
+include
+lib
+pyvenv.cfg
+pyvtt.doxygen
+README.md
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM python:3
+FROM python:3-slim
 
-WORKDIR /opt/pyvtt
+RUN useradd -d /app -m vtt
+
+USER vtt 
+WORKDIR /app/
+RUN python3 -m venv /app
+ENV PATH="/app/bin:$PATH"
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD [ "python3", "./vtt.py" ]
+CMD [ "python3", "./vtt.py", "--appname=prod", "--prefdir=/opt/pyvtt" ]


### PR DESCRIPTION
This substantially reduces the Docker image size: down from 1.1GB to about 291MB.

Edit the Dockerfile if you need to change the `appname` or `prefdir`. You don't need to change the `prefdir` if you don't want to, because you can mount a host volume into the container at that location.

To build:
```
docker build -t pyvtt .
```

To run it:
```
docker run -d --restart=on-failure -p 8080:8080 -v /home/skippy/pyvtt:/opt/pyvtt/prod --name icvtt pyvtt
```
