### PR TITLE
allow for using non default values with run.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 TAG="${1:-latest}"
 SHA=$(git rev-parse --short HEAD)
-echo ${SHA} > sha.txt
-docker build -t pyvtt:${SHA} .
-docker tag pyvtt:${SHA} pyvtt:${TAG}
+echo "${SHA}" > sha.txt
+docker build -t pyvtt:"${SHA}" .
+docker tag pyvtt:"${SHA}" pyvtt:"${TAG}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,4 +27,4 @@ TAG=$1; shift;
 
 docker stop icvtt-${TAG}
 docker rm icvtt-${TAG}
-docker run -d -p ${PORT}:${PORT} -v ${VOLUME}:${VOLUME} --restart=on-failure --name icvtt-${TAG} pyvtt:${TAG} "$@"
+docker run -d -p ${PORT}:8080 -v ${VOLUME}:/opt/pyvtt/prod --restart=on-failure --name icvtt-${TAG} pyvtt:${TAG} "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -25,6 +25,6 @@ shift $((OPTIND-1))
 # get the tag, and remove it from arguments
 TAG=$1; shift;
 
-docker stop icvtt-${TAG}
-docker rm icvtt-${TAG}
-docker run -d -p ${PORT}:8080 -v ${VOLUME}:/opt/pyvtt/prod --restart=on-failure --name icvtt-${TAG} pyvtt:${TAG} "$@"
+docker stop icvtt-"${TAG}"
+docker rm icvtt-"${TAG}"
+docker run -d -p "${PORT}":8080 -v "${VOLUME}":/opt/pyvtt/prod --restart=on-failure --name icvtt-"${TAG}" pyvtt:"${TAG}" "$@"


### PR DESCRIPTION
The current run.sh script uses the input as both the host and docker side mapping for port and volume, This makes it so that the contain will crash loop when providing a volume other than the default, and the server will not have the correct port mapping when passing in any value other than the default. this commit fixes that behavior