### PR TITLE
Multi-row player list when dragged to screen edge

### DIFF
--- a/static/client/layout.css
+++ b/static/client/layout.css
@@ -863,10 +863,8 @@ div.rollbox > span > span.maxani {
 
 div#players {
     position: absolute;
-    left: 50%;
-    bottom: 0px;
     height: 56px;
-    display: block;
+    display: table;
 }
 
 div#players > span.player {

--- a/static/client/layout.css
+++ b/static/client/layout.css
@@ -861,22 +861,16 @@ div.rollbox > span > span.maxani {
 
 /* --- Players list ------------------------------------------------- */
 
-div#players {  
-    position: absolute; 
+div#players {
+    position: absolute;
     left: 50%;
     bottom: 0px;
-    
     height: 56px;
-    transform: translate(-50%, 0%);
-     
     display: block;
-    
-    white-space: nowrap;
 }
 
-div#players > span.player {    
+div#players > span.player {
     display: inline-block;
-    height: 20px;
     padding: 10px;
     margin: 7px;
     font-size: larger;
@@ -885,7 +879,6 @@ div#players > span.player {
     text-align: center;
     color: black;
     min-width: 80px;
-
     cursor: grab;
 }
 

--- a/static/client/ui.js
+++ b/static/client/ui.js
@@ -2017,9 +2017,9 @@ function onResetPlayers(event) {
         var target = $('#players');
         var pos = [
             parseInt(window.innerWidth * 0.5),
-            parseInt(window.innerHeight - 1.5 * target.height() + 25)
+            parseInt(window.innerHeight - 0.5 * target.height() - 20)
         ];
-        
+
         // apply position
         movePlayersTo(pos);
         localStorage.removeItem('players');

--- a/static/client/ui.js
+++ b/static/client/ui.js
@@ -2240,20 +2240,16 @@ function onDragPlayers(event) {
     var target = $('#players');
     var w = target.width();
     var h = target.height();
-    var player_w = target.children().first().width();
 
-    // Prevent dragging player list so far into the lower-right corner that
-    // the first player is unclickable (behind the auth info), and the rest of
-    // the players are off the screen.
-    if (p[0] >= (window.innerWidth - player_w)) {
-        pad = h
-    } else {
-        pad = 0
-    }
+    // Gets the maximum width of any player box, including the margin.
+    // The '- 3' allows dragging the players slightly closer to the edge of
+    // the screen, which allows the player box width to continue collapsing
+    // after a multi-word player name is word wrapped.
+    var max_p_w = Math.max([target.children()].map(i => i.outerWidth(true))) - 3;
 
-    // limit position of the first player in the list to the screen
-    var x = parseInt(Math.max(0,     Math.min(window.innerWidth  - player_w / 2, p[0])));
-    var y = parseInt(Math.max(h / 2, Math.min(window.innerHeight - h / 2 - pad,  p[1])));
+    // limit position of list to be on the screen
+    var x = parseInt(Math.max(max_p_w / 2, Math.min(window.innerWidth  - max_p_w / 2, p[0])));
+    var y = parseInt(Math.max(      h / 2, Math.min(window.innerHeight -       h / 2, p[1])));
     var pos = [x, y];
 
     movePlayersTo(pos);

--- a/static/client/ui.js
+++ b/static/client/ui.js
@@ -2154,9 +2154,10 @@ function moveDiceTo(data, sides) {
 }
 
 function movePlayersTo(pos) {
-    var target = $('#players'); 
-    target.css('left', pos[0]);
-    target.css('top',  pos[1]);
+    var target = $('#players');
+    target.css('left', pos[0] - target.width()  / 2);
+    target.css('top',  pos[1] - target.height() / 2);
+    target.css('max-width', pos[0] * 2)
 }
 
 function moveMusicTo(pos) {
@@ -2237,14 +2238,24 @@ function onDragDice(event) {
 function onDragPlayers(event) {
     var p = pickScreenPos(event);
     var target = $('#players');
-    
-    // limit position to the screen
     var w = target.width();
     var h = target.height();
-    var x = parseInt(Math.max(w / 2, Math.min(window.innerWidth - w/2, p[0])));
-    var y = parseInt(Math.max(0,     Math.min(window.innerHeight - 1.5 * h + 25,  p[1])));
+    var player_w = target.children().first().width();
+
+    // Prevent dragging player list so far into the lower-right corner that
+    // the first player is unclickable (behind the auth info), and the rest of
+    // the players are off the screen.
+    if (p[0] >= (window.innerWidth - player_w)) {
+        pad = h
+    } else {
+        pad = 0
+    }
+
+    // limit position of the first player in the list to the screen
+    var x = parseInt(Math.max(0,     Math.min(window.innerWidth  - player_w / 2, p[0])));
+    var y = parseInt(Math.max(h / 2, Math.min(window.innerHeight - h / 2 - pad,  p[1])));
     var pos = [x, y];
-    
+
     movePlayersTo(pos);
     savePlayersPos(pos);
 }


### PR DESCRIPTION
This allows the player list to break into multiple rows when it is dragged close to the left or right edge of the screen, as demonstrated in the attached video.

https://github.com/cgloeckner/pyvtt/assets/22459166/0f2e9dae-b0d7-44fe-a9a1-a8abb074dcd3

Only the first (top-left) player in the player list is constrained to be on the screen. This means that when the player list is close enough to the bottom corners, some of the players will be off the screen. Since this pull request was inspired by [a request](https://discord.com/channels/396804812940771328/707223272206630972/1239029459659526144) to move the player list out of the way, I guess this could be considered a feature rather than a bug. I included some code that prevents the player list from being dragged so far into the bottom-right corner that only one player is visible, because this can result in a situation where the whole list is either off the screen or behind the authentication information box, making it impossible to click on the list to drag it somewhere else.

I tested this in two browsers, Firefox and Qutebrowser (based on QtWebEngine, which is based on Chromium if I understand correctly). I only tested by changing the CSS and JS in the in-browser developer tools, not by deploying a modified version of pyvtt. I'm not sure how likely that is to cause problems in a proper deployment.