### PR TITLE
Streamline footer links

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,44 @@
+# TERMS & DISCLAIMERS
+
+## Terms of Use
+By using the Index Card Virtual Tabletop (ICVTT), you agree to the following rules and conditions:
+
+* We NEVER use any private data for any purpose but to login to, and use the ICVTT servers.
+* Keymetrics and Google Analytics may be used, anonymously, to bolster server performance by region, and for no other purpose.
+* All uploaded media retains its original copyrights, and is only used and stored to be displayed by users in games. By uploading media you guarantee, that no copyright is violated.
+* Inappropriate or offensive content is entirely the responsibility of users. Deletion can be requested by notifying us.
+* You can remove your account from the ICVTT server by not logging in for a while. Your login data and all uploaded media will be deleted permanently on the next update cycle.
+* You must be at least 13 years of age to use ICVTT.
+* ICVTT is presented with no warranty of any kind.
+* Service may be discontinued at any time.
+* ICVTT uses 'cookies' to authenticate logins and solely to maintain your 'logged in' status. Cookies are never shared in any way.
+
+Thanks for using the Index Card Virtual Table Top. Report issues on <a href="https://github.com/cgloeckner/pyvtt/issues">GitHub</a> or <a href="https://discord.gg/H76tfBZZEX">Discord</a>. You can also mail us: <a href="mailto:contact@icvtt.net">contact@icvtt.net</a>.
+
+## DISCLAIMER for pyvtt
+
+ICVTT is based on <a href="https://github.com/cgloeckner/pyvtt">PyVTT</a>.
+
+```
+MIT License
+
+Copyright (c) Christian Glöckner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/vtt/engine.py
+++ b/vtt/engine.py
@@ -85,15 +85,12 @@ class Engine(object):
                 "label" : "HOME",
                 "url"   : "/"
             }, {
-                "label" : "ROADMAP",
-                "url"   : "/static/roadmap.html"
-            }, {
                 "label" : "TERMS",
-                "url"   : "/static/terms.html"
+                "url"   : "https://github.com/cgloeckner/pyvtt/blob/master/TERMS.md"
             }
         ]
 
-        for category in ['discord', 'faq']:
+        for category in ['discord', 'github']:
             key = f'VTT_LINKS_{category.upper()}'
             value = os.getenv(key)
             if value is not None:


### PR DESCRIPTION
Remove `Roadmap`. Swap `FAQ` for `GitHub`. Point `TERMS` to new page maintained here.