### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/static/client/gm.js
+++ b/static/client/gm.js
@@ -84,7 +84,12 @@ function updateCountdown() {
     let d = getSchedulerDate()
     url += d.getTime().toString(16)
 
-    $('#schedule_url')[0].innerHTML = `<a href="${server}${url}" target="_blank">${server}${url}</a>`
+    let anchor = document.createElement('a');
+    anchor.href = `${server}${url}`;
+    anchor.target = "_blank";
+    anchor.textContent = `${server}${url}`;
+    $('#schedule_url')[0].innerHTML = '';
+    $('#schedule_url')[0].appendChild(anchor);
     // note: escape some chars
     $('#discord_prompt')[0].innerHTML = getDiscordPrompt(d).replace(/<|>/g, e => e === '<' ? '&lt;' : '&gt;')
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cgloeckner/pyvtt/security/code-scanning/1](https://github.com/cgloeckner/pyvtt/security/code-scanning/1)

To fix the problem, we need to ensure that the value of `server` is properly sanitized before being used to construct the HTML string. One way to do this is to use a text node to safely insert the value into the DOM, which will automatically escape any potentially dangerous characters.

- Replace the direct insertion of the HTML string with a safer method that uses text nodes.
- Specifically, we will create an anchor element, set its properties using safe methods, and then insert it into the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
