### PR TITLE
add fly.io config files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ pyvenv.cfg
 pyvtt.doxygen
 README.md
 test
+fly-dev.toml
+fly-prod.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 RUN useradd -d /app -m vtt
 

--- a/fly-dev.toml
+++ b/fly-dev.toml
@@ -1,0 +1,36 @@
+# fly.toml app configuration file generated for icvtt-dev on 2025-04-07T12:54:20-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'icvtt-dev'
+primary_region = 'ord'
+
+[build]
+
+[env]
+  MAX_PLAYER_COUNT = '15'
+  VTT_DOMAIN = 'dev.icvtt.net'
+  VTT_LINKS_DISCORD = 'https://discord.gg/H76tfBZZEX'
+  VTT_LINKS_GITHUB = 'https://github.com/cgloeckner/pyvtt/'
+  VTT_PORT = '9000'
+  VTT_PREFDIR = '/data'
+  VTT_SSL = 'true'
+  VTT_TITLE = 'ICVTT DEV'
+
+[[mounts]]
+  source = 'dev'
+  destination = '/data'
+
+[http_service]
+  internal_port = 9000
+  force_https = true
+  auto_stop_machines = 'suspend'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '256mb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/fly-prod.toml
+++ b/fly-prod.toml
@@ -1,0 +1,36 @@
+# fly.toml app configuration file generated for pyvtt on 2025-03-14T13:31:21-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'icvtt'
+primary_region = 'ord'
+
+[build]
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '512mb'
+  cpu_kind = 'shared'
+  cpus = 1
+
+[env]
+  VTT_TITLE = "ICVTT" 
+  VTT_PREFDIR = "/data/" 
+  VTT_DOMAIN = "app.icvtt.net" 
+  VTT_SSL = "true" 
+  VTT_PORT = 8000
+  VTT_LINKS_DISCORD = "https://discord.gg/H76tfBZZEX" 
+  VTT_LINKS_GITHUB = "https://github.com/cgloeckner/pyvtt/" 
+  MAX_PLAYER_COUNT = "15"
+
+[mounts]
+  source = "prod"
+  destination = "/data"


### PR DESCRIPTION
I've moved hosting of the app from my personal VPS to https://fly.io/. This affords a few benefits:
- I can perform maintenance on my VPS without worrying about interrupting a game
- fly provides basic Grafana metrics as part of the default offering
- fly supports live and historical logs, which can be accessed via the fly.io console without logging into the running app
- fly supports "teams" which means I can add glocke and anyone else to join the team to see and manage the apps
- fly supports GitHub integrations which we may use to automatically build and deploy new instances of the app upon commit or merge

Right now, I'm having fly build the container image when we deploy. This could be eliminated if we build (manually or via GitHub Actions) and push to a public registry (presumably GitHub?). Then fly could pull the referenced image and save some deploy time.

Included in this PR are two files:
- fly-dev.toml: the config for `icvtt-dev.fly.dev` (DNS CNAME'd to `dev.icvtt.net`). This uses a 256MB shared CPU VM.
- fly-prod.toml: the config for `icvtt.fly.dev` (DNS CNAME'd to `app.icvtt.net`). This uses a 512MB shared CPU VM.

Both are configured to suspend after no activity. The default is, I think, 5 minutes. We can extend that, or turn it off entirely, as desired.

Each app has secrets defined for the OAuth secrets. These get injected into the runtime environment. That keeps secrets out of version control.

Each app has a dedicated fly volume attached to it for persistent data (SQLite DBs, user uploads). dev has a 1GB volume and prod has a 4GB volume. We can extend these as needed (and I think they'll extend automatically. They can never be reduced).

If you make a code change or a config change, you can build and deploy it with the fly CLI. You'll need to pass the app name and the config file to use:
```
fly deploy -a icvtt -c fly-prod.toml # build and launch the prod app
fly deploy -a icvtt-dev -c fly-dev.toml # build and launch the dev app
```
